### PR TITLE
Set inotify limit to 512K which is needed by PhpStorm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ env:
   - distro: centos7
     init: /usr/lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-  - distro: fedora24
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   - distro: ubuntu1604
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.1] - 2017-02-07
+### Fixed
+- Set inotify limit to 512K which is needed by PhpStorm
+
 ## [1.0.0] - 2017-02-01
 ### Added
 - Created the role to provision the Jetbrains PhpStorm IDE
 - Add variables to define the installed PhpStorm version and install path
 - Test the role on CentOS 7, Fedora 2.4, Ubuntu 16.04 and Debian 8
 
+[1.0.1]: https://github.com/pixelart/ansible-role-phpstorm/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/pixelart/ansible-role-phpstorm/compare/d4b3ad1...1.0.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,3 +51,13 @@
   file:
     dest: "/tmp/{{ phpstorm_package }}"
     state: absent
+
+# See https://confluence.jetbrains.com/display/IDEADEV/Inotify+Watches+Limit
+- name: Set inotify watches limit to 512K
+  sysctl:
+    name: fs.inotify.max_user_watches
+    value: 524288
+    sysctl_file: /etc/sysctl.d/20-idea.conf
+    sysctl_set: yes
+    state: present
+    reload: yes

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,10 +7,6 @@
       apt: update_cache=yes cache_valid_time=600
       when: ansible_distribution == 'Ubuntu'
 
-    - name: Install gtar.
-      package: name=tar state=installed
-      when: ansible_distribution == 'Fedora'
-
   roles:
     - geerlingguy.java
     - role_under_test


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #1
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

The standard inotify watches limit is too small for working with PhpStorm. They recommend to increase them to 512K, see https://confluence.jetbrains.com/display/IDEADEV/Inotify+Watches+Limit