### PR TITLE
Create PhpStorm command line launcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ script:
     || (echo 'Idempotence test: fail' && exit 1)
 
   # Ensure PhpStorm is installed and working (still won't startup because there is no graphics environment).
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm /opt/jetbrains/phpstorm-2016.3.2/bin/phpstorm.sh || true'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash -c "/opt/jetbrains/phpstorm-*/bin/phpstorm.sh"; [ $? == 1 ]'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm pstorm; [ $? == 1 ]'
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
 
   # Ensure PhpStorm is installed and working (still won't startup because there is no graphics environment).
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm bash -c "/opt/jetbrains/phpstorm-*/bin/phpstorm.sh"; [ $? == 1 ]'
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm pstorm; [ $? == 1 ]'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm phpstorm; [ $? == 1 ]'
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Create PhpStorm command line launcher `pstorm`
+- Create PhpStorm command line launcher `pstorm` (configurable)
 
 ### Changed
 - Finally deactivate the automated update checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Create PhpStorm command line launcher `pstorm`
+
 ### Changed
 - Finally deactivate the automated update checks
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ None.
       roles:
         - pixelart.phpstorm
 
-After the playbook runs, PhpStorm will be installed, and an application launcher will be accessible via normal user accounts.
+After the playbook runs, PhpStorm will be installed, and an application and command line launcher will be accessible via normal user accounts.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The version of PhpStorm which should be installed.
 
 The path where PhpStorm will be installed and available to your system.
 
+    phpstorm_commandline_launcher: 'pstorm'
+    
+The executable name of the command-line launcher. Set to `False` if you don't want to install one.
+
 ## Dependencies
 
 None.
@@ -30,7 +34,7 @@ None.
       roles:
         - pixelart.phpstorm
 
-After the playbook runs, PhpStorm will be installed, and an application and command line launcher will be accessible via normal user accounts.
+After the playbook runs, PhpStorm will be installed, and an application and a command-line launcher will be accessible via normal user accounts.
 
 ## Code of Conduct
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 phpstorm_version: '2017.1.3'
 phpstorm_install_path: '/opt/jetbrains/phpstorm-{{ phpstorm_version }}'
+phpstorm_commandline_launcher: 'pstorm'
 
 # Donwload URLs
 phpstorm_package: 'PhpStorm-{{ phpstorm_version }}.tar.gz'

--- a/tasks/configure-launchers.yml
+++ b/tasks/configure-launchers.yml
@@ -4,3 +4,9 @@
     src: jetbrains-phpstorm.desktop.j2
     dest: /usr/share/applications/jetbrains-phpstorm.desktop
     mode: 0644
+
+- name: Create PhpStorm command line launcher
+  template:
+    src: pstorm.j2
+    dest: /usr/local/bin/pstorm
+    mode: 0755

--- a/tasks/configure-launchers.yml
+++ b/tasks/configure-launchers.yml
@@ -8,5 +8,6 @@
 - name: Create PhpStorm command line launcher
   template:
     src: pstorm.j2
-    dest: /usr/local/bin/pstorm
+    dest: /usr/local/bin/{{ phpstorm_commandline_launcher }}
     mode: 0755
+  when: phpstorm_commandline_launcher != false

--- a/templates/pstorm.j2
+++ b/templates/pstorm.j2
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import socket
+import struct
+import sys
+import os
+import time
+
+# see com.intellij.idea.SocketLock for the server side of this interface
+
+RUN_PATH = u'{{ phpstorm_install_path }}/bin/phpstorm.sh'
+CONFIG_PATH = os.path.expanduser('~') + u'/.PhpStorm{{ phpstorm_version|regex_replace('^(?P<major>\\d+).(?P<minor>\\d+)(.\\d+)?$', '\\g<major>.\\g<minor>') }}/config'
+SYSTEM_PATH = os.path.expanduser('~') + u'/.PhpStorm{{ phpstorm_version|regex_replace('^(?P<major>\\d+).(?P<minor>\\d+)(.\\d+)?$', '\\g<major>.\\g<minor>') }}/system'
+
+
+def print_usage(cmd):
+    print(('Usage:\n' +
+           '  {0} -h | -? | --help\n' +
+           '  {0} [project_dir]\n' +
+           '  {0} [-l|--line line] [project_dir|--temp-project] file[:line]\n' +
+           '  {0} diff <left> <right>\n' +
+           '  {0} merge <local> <remote> [base] <merged>').format(cmd))
+
+
+def process_args(argv):
+    args = []
+
+    skip_next = False
+    for i, arg in enumerate(argv[1:]):
+        if arg == '-h' or arg == '-?' or arg == '--help':
+            print_usage(argv[0])
+            exit(0)
+        elif i == 0 and (arg == 'diff' or arg == 'merge' or arg == '--temp-project'):
+            args.append(arg)
+        elif arg == '-l' or arg == '--line':
+            args.append(arg)
+            skip_next = True
+        elif skip_next:
+            args.append(arg)
+            skip_next = False
+        else:
+            path = arg
+            if ':' in arg:
+                file_path, line_number = arg.rsplit(':', 1)
+                if line_number.isdigit():
+                    args.append('-l')
+                    args.append(line_number)
+                    path = file_path
+            args.append(os.path.abspath(path))
+
+    return args
+
+
+def try_activate_instance(args):
+    port_path = os.path.join(CONFIG_PATH, 'port')
+    token_path = os.path.join(SYSTEM_PATH, 'token')
+    if not (os.path.exists(port_path) and os.path.exists(token_path)):
+        return False
+
+    with open(port_path) as pf:
+        port = int(pf.read())
+    with open(token_path) as tf:
+        token = tf.read()
+
+    s = socket.socket()
+    s.settimeout(0.3)
+    try:
+        s.connect(('127.0.0.1', port))
+    except (socket.error, IOError):
+        return False
+
+    found = False
+    while True:
+        try:
+            path_len = struct.unpack('>h', s.recv(2))[0]
+            path = s.recv(path_len)
+            if os.path.abspath(path) == os.path.abspath(CONFIG_PATH):
+                found = True
+                break
+        except (socket.error, IOError):
+            return False
+
+    if found:
+        cmd = 'activate ' + token + '\0' + os.getcwd() + '\0' + '\0'.join(args)
+        encoded = struct.pack('>h', len(cmd)) + cmd
+        s.send(encoded)
+        time.sleep(0.5)  # don't close the socket immediately
+        return True
+
+    return False
+
+
+def start_new_instance(args):
+    if sys.platform == 'darwin':
+        if len(args) > 0:
+            args.insert(0, '--args')
+        os.execvp('open', ['-a', RUN_PATH] + args)
+    else:
+        bin_file = os.path.split(RUN_PATH)[1]
+        os.execv(RUN_PATH, [bin_file] + args)
+
+
+ide_args = process_args(sys.argv)
+if not try_activate_instance(ide_args):
+    start_new_instance(ide_args)

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,6 +2,9 @@
 - hosts: localhost
   remote_user: root
 
+  vars:
+    phpstorm_commandline_launcher: phpstorm
+
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #11 
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Create PhpStorm command line launcher, flexible for the calling user.

The executable name is configurable and can't be deactivated to be installed too.

#### Example Usage

```yaml
# if you want an alternative executable name
phpstorm_commandline_launcher: phpstorm

# don't install the command-line launcher
phpstorm_commandline_launcher: false
```