### PR TITLE
Add configuration to define releases to cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Create PhpStorm command line launcher `pstorm` (configurable)
+- Add configuration to define releases to cleanup
 
 ### Changed
 - Finally deactivate the automated update checks
+
+### Upgrade needed
+
+If you have overwritten the `phpstorm_install_path` variable in the past, please split it up to use `phpstorm_install_basepath` and `phpstorm_install_prefix` instead.
+
+Your overwrite of `phpstorm_install_path` will continue to work, but you won't be able to cleanup old releases, because your path won't match with the new defaults for cleanup. 
 
 ## [1.0.2] - 2017-05-09
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,13 +16,23 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The version of PhpStorm which should be installed.
 
-    phpstorm_install_path: '/opt/jetbrains/phpstorm-{{ phpstorm_version }}'
+    phpstorm_install_basepath: '/opt/jetbrains'
 
-The path where PhpStorm will be installed and available to your system.
+The base path where PhpStorm will be installed.
+
+    phpstorm_install_prefix: 'phpstorm'
+    
+The prefix of the installation folder within the installation path. Together with `phpstorm_version` and `phpstorm_install_basepath` this will result in the following default install path: `/opt/jetbrains/phpstorm-2017.1.3`.
 
     phpstorm_commandline_launcher: 'pstorm'
     
 The executable name of the command-line launcher. Set to `False` if you don't want to install one.
+
+    phpstorm_cleanup_releases: []
+    
+Version number of old PhpStorm releases you want to delete. It is important to not change `phpstorm_install_basepath` and `phpstorm_install_prefix` between installation if want to cleanup. Otherwise old versions won't be found.
+
+Side note: Never delete the version from whom you are upgrading. It may be opened by a developer and this will lead to crashes.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,12 @@
 ---
 phpstorm_version: '2017.1.3'
-phpstorm_install_path: '/opt/jetbrains/phpstorm-{{ phpstorm_version }}'
+phpstorm_install_basepath: '/opt/jetbrains'
+phpstorm_install_prefix: 'phpstorm'
+phpstorm_install_path: '{{ phpstorm_install_basepath }}/{{ phpstorm_install_prefix }}-{{ phpstorm_version }}'
+
 phpstorm_commandline_launcher: 'pstorm'
+
+phpstorm_cleanup_releases: []
 
 # Donwload URLs
 phpstorm_package: 'PhpStorm-{{ phpstorm_version }}.tar.gz'

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -45,3 +45,9 @@
   file:
     dest: "/tmp/{{ phpstorm_package }}"
     state: absent
+
+- name: Cleanup old releases
+  file:
+    dest: "{{ phpstorm_install_basepath }}/{{ phpstorm_install_prefix }}-{{ item }}"
+    state: absent
+  with_items: "{{ phpstorm_cleanup_releases }}"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | yes
| Fixed tickets | fixes #14 
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Add configuration to define releases to cleanup.

#### Example Usage

```yaml
phpstorm_cleanup_releases:
  - '2016.3.2'
  - '2017.1'
  - '2017.1.2'
```

#### BC Breaks/Deprecations

The `phpstorm_install_path` variable to override is deprecated. You should use `phpstorm_install_basepath` and `phpstorm_install_prefix` instead.