### PR TITLE
Fix how the *.vmoptions files are discovered

### DIFF
--- a/tasks/configure-updates.yml
+++ b/tasks/configure-updates.yml
@@ -1,7 +1,13 @@
 ---
-- name: Deactivate PhpStorm update checks
+- name: Find vmoptions files
+  find:
+    paths: '{{ phpstorm_install_path }}/bin'
+    patterns: '*.vmoptions'
+  register: phpstorm_vmoptions_files
+
+- name: Disable PhpStorm update checks
   lineinfile:
-    path: '{{ item }}'
+    path: '{{ item.path }}'
     regexp: '^-Dide\.no\.platform\.update'
     line: '-Dide.no.platform.update=true'
-  with_fileglob: '{{ phpstorm_install_path }}/bin/*.vmoptions'
+  with_items: '{{ phpstorm_vmoptions_files.files }}'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #4
| Related issues/PRs | #12 
| License | MIT

#### What's in this PR?

Fixes how the *.vmoptions files are discovered in the install path. `with_fileglobs` works on local files not remote.