### PR TITLE
:green_heart: Raise default phpstorm version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-phpstorm_version: '2017.1.3'
+phpstorm_version: '2019.3.4'
 phpstorm_install_basepath: '/opt/jetbrains'
 phpstorm_install_prefix: 'phpstorm'
 phpstorm_install_path: '{{ phpstorm_install_basepath }}/{{ phpstorm_install_prefix }}-{{ phpstorm_version }}'


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

The old default phpstorm version (2017.1.3) is not available for download anymore.
That made the ci tests fail. Raised the version to the latest stable, so that the tests succeed again.

#### Why?

The CI tests failed. Now they are green again.
